### PR TITLE
Missing PublisherId

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,6 @@ Repository = "https://github.com/Extraltodeus/Negative-attention-for-ComfyUI-"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = ""
+PublisherId = "extraltodeus"
 DisplayName = "Negative-attention-for-ComfyUI-"
 Icon = ""


### PR DESCRIPTION
If you have this empty because you don't want to publish it yet, then you can ignore this and I am sorry to bother.

I noticed the github action failed because the PublisherID was empty.


I also see the following when opening a workflow with just nodes from this repository in it. But i think that is because of a recent change in comfyUI frontend.

```
Invalid workflow against zod schema:
Validation error: Invalid aux_id: Must be valid 'github-username/github-repo-name' at "nodes[7].properties.aux_id"; Invalid aux_id: Must be valid 'github-username/github-repo-name' at "nodes[22].properties.aux_id"
```